### PR TITLE
Update prerequisitions for some various techs

### DIFF
--- a/apm_power/info.json
+++ b/apm_power/info.json
@@ -1,6 +1,6 @@
 {
         "name": "apm_power_ldinc",
-        "version": "0.22.01",
+        "version": "0.22.02",
         "title": "Amator Phasma's Coal & Steam (forked)",
         "author": "AmatorPhasma",
         "dependencies": [

--- a/apm_power/prototypes/main/technologies-overwrites.lua
+++ b/apm_power/prototypes/main/technologies-overwrites.lua
@@ -95,3 +95,14 @@ apm.lib.utils.technology.add.prerequisites('weapon-shooting-speed-2', 'logistic-
 apm.lib.utils.technology.add.prerequisites('physical-projectile-damage-2', 'logistic-science-pack')
 
 apm.lib.utils.technology.force.recipe_for_unlock('uranium-processing', 'apm_coal_ash_washing')
+
+-- additional dependencies now that red science needs to be researched
+apm.lib.utils.technology.add.prerequisites('gun-turret', 'apm_power_automation_science_pack')
+apm.lib.utils.technology.add.prerequisites('stone-wall', 'apm_power_automation_science_pack')
+
+-- this is needed here as opposed to the base game, as in the base
+-- game it is not possible to get to lubricant until after reaching
+-- chemical science
+apm.lib.utils.technology.add.prerequisites('electric-engine', 'engine')
+
+apm.lib.utils.technology.add.prerequisites('robotics', 'chemical-science-pack')

--- a/apm_power/prototypes/main/technologies.lua
+++ b/apm_power/prototypes/main/technologies.lua
@@ -451,7 +451,7 @@ apm.lib.utils.technology.new('apm_power',
 -- Electric crusher
 apm.lib.utils.technology.new('apm_power',
     'apm_crusher_machine_2',
-    {'apm_crusher_machine_1', 'electric-engine'}, 
+    {'apm_crusher_machine_1', 'electric-engine', 'chemical-science-pack'},
     {'apm_crusher_machine_2'},
     {{"automation-science-pack", 1}, {"logistic-science-pack", 1}, {"chemical-science-pack", 1}},
     75, 30)
@@ -459,7 +459,7 @@ apm.lib.utils.technology.new('apm_power',
 -- Electric press
 apm.lib.utils.technology.new('apm_power',
     'apm_press_machine_2',
-    {'apm_press_machine_1', 'electric-engine'}, 
+    {'apm_press_machine_1', 'electric-engine', 'chemical-science-pack'},
     {'apm_press_machine_2'},
     {{"automation-science-pack", 1}, {"logistic-science-pack", 1}, {"chemical-science-pack", 1}},
     75, 30)
@@ -467,7 +467,7 @@ apm.lib.utils.technology.new('apm_power',
 -- Electric centrifuge
 apm.lib.utils.technology.new('apm_power',
     'apm_centrifuge_2',
-    {'apm_centrifuge_0', 'electric-engine'}, 
+    {'apm_centrifuge_0', 'electric-engine', 'chemical-science-pack'},
     {'apm_centrifuge_2'},
     {{"automation-science-pack", 1}, {"logistic-science-pack", 1}, {"chemical-science-pack", 1}},
     75, 30)
@@ -475,7 +475,7 @@ apm.lib.utils.technology.new('apm_power',
 -- Greenhouse III
 apm.lib.utils.technology.new('apm_power',
     'apm_greenhouse-3',
-    {'apm_greenhouse-2','electric-engine'}, 
+    {'apm_greenhouse-2', 'electric-engine', 'chemical-science-pack'},
     {'apm_greenhouse_2'},
     {{"automation-science-pack", 1}, {"logistic-science-pack", 1}, {"chemical-science-pack", 1}},
     75, 30)
@@ -483,7 +483,7 @@ apm.lib.utils.technology.new('apm_power',
 -- Equipment Burner Generator I
 apm.lib.utils.technology.new('apm_power',
     'apm_equipment_burner_generator-1',
-    {'modular-armor','electric-engine'},
+    {'modular-armor', 'electric-engine', 'chemical-science-pack'},
     {'apm_equipment_burner_generator_basic'},
     {{"automation-science-pack", 1}, {"logistic-science-pack", 1}, {"chemical-science-pack", 1}},
     150, 30)


### PR DESCRIPTION
Some technologies cannot be researched or used until other techs are researched.  For example, electric engines cannot be made until regular engines are researched, and turrets and walls cannot be researched until red science is researched.

There are many upgrade researches which have a similar issue, but the standard in the base game is to not include the prerequisites.  For the electric crusher etc, though, I propose including blue science, as it looks more like a new type of crusher rather than an upgrade in the style of the weapons upgrades.